### PR TITLE
class member access on instantiation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         }
     ],
     "require": {
+        "php": "~5.4.0",
         "silex/silex": "~1.2",
         "alecsammon/php-raml-parser": "1.0.0.x-dev",
         "doctrine/dbal": "~2.4",


### PR DESCRIPTION
added minimal PHP 5.4 version

See:
https://github.com/marmelab/microrest.php/blob/master/src/MicrorestServiceProvider.php#L17
